### PR TITLE
Dont query `INFORMATION_SCHEMA`

### DIFF
--- a/editoria11y.php
+++ b/editoria11y.php
@@ -179,81 +179,86 @@ class Editoria11y {
 		}
 
 		// Add foreign keys not reliably handled by maybe_create_table
-		$results_constraint = $wpdb->prefix . 'ed11y_results_pid';
-		$dismissal_constraint = $wpdb->prefix . 'ed11y_dismissal_pid';
-		$result_foreign_key = $wpdb->get_var( // phpcs:ignore
-			$wpdb->prepare( "SELECT b.constraint_name
-	          FROM information_schema.table_constraints a
-	          JOIN information_schema.key_column_usage b
-	          ON a.table_schema = b.table_schema AND a.constraint_name = b.constraint_name
-	          WHERE a.table_schema=database() AND a.constraint_type='FOREIGN KEY' AND b.table_name = %s;",
-				array( $table_results )
-			)
-		);
-		if ( $result_foreign_key ) {
-			try {
-				// MySQL syntax
-				$wpdb->get_var( // phpcs:ignore
-					$wpdb->prepare( "ALTER TABLE $table_results
-        		DROP FOREIGN KEY %1s;", array( $result_foreign_key ) )
-				);
-			} catch (Exception $e) {
-				// MariaDB syntax
-				$wpdb->get_var( // phpcs:ignore
-					$wpdb->prepare( "ALTER TABLE $table_results
-        		DROP CONSTRAINT %1s;", array( $result_foreign_key ) )
-				);
-			} finally {
-				// Add replacement constraint
-				$wpdb->get_var( // phpcs:ignore
-					$wpdb->prepare( "ALTER TABLE $table_results
-        		ADD CONSTRAINT %1s FOREIGN KEY(pid) REFERENCES $table_urls (pid) ON DELETE CASCADE", $results_constraint)
-				);
-			}
-		} else {
-			// Add new constraint
-			$wpdb->get_var( // phpcs:ignore
-				$wpdb->prepare( "ALTER TABLE $table_results
-        		ADD CONSTRAINT %1s FOREIGN KEY(pid) REFERENCES $table_urls (pid) ON DELETE CASCADE", $results_constraint)
-			);
-		}
+		$results_create_table_sql_row = $wpdb->get_row( "SHOW CREATE TABLE $table_results" );
+		if ( $results_create_table_sql_row ) {
+			$results_create_table_sql = $results_create_table_sql_row->{'Create Table'};
+			$results_constraint       = $wpdb->prefix . 'ed11y_results_pid';
 
-		$dismissal_key = $wpdb->get_var( // phpcs:ignore
-			$wpdb->prepare( "SELECT b.constraint_name
-	          FROM information_schema.table_constraints a
-	          JOIN information_schema.key_column_usage b
-	          ON a.table_schema = b.table_schema AND a.constraint_name = b.constraint_name
-	          WHERE a.table_schema=database() AND a.constraint_type='FOREIGN KEY' AND b.table_name = %s;",
-				array( $table_dismissals )
-			)
-		);
-		if ( $dismissal_key ) {
-			try {
-				// MySQL syntax
-				$wpdb->get_var( // phpcs:ignore
-					$wpdb->prepare( "ALTER TABLE $table_dismissals
-					DROP FOREIGN KEY %1s;", array( $dismissal_key ) )
-				);
-			} catch (Exception $e) {
-				// MariaDB syntax
-				$wpdb->get_var( // phpcs:ignore
-					$wpdb->prepare( "ALTER TABLE $table_dismissals
-					DROP CONSTRAINT %1s;", array( $dismissal_key ) )
-				);
-			} finally {
+			$result_constraint_matches = preg_match( '/CONSTRAINT `(.+?)` FOREIGN KEY \(`pid`\)/', $results_create_table_sql, $result_matches );
+
+			$result_foreign_key = null;
+			if ( $result_constraint_matches ) {
+				$result_foreign_key = $result_matches[1];
+			}
+
+			if ( $result_foreign_key ) {
+				try {
+					// MySQL syntax
+					$wpdb->get_var( // phpcs:ignore
+						$wpdb->prepare( "ALTER TABLE $table_results
+					DROP FOREIGN KEY %1s;", array( $result_foreign_key ) )
+					);
+				} catch (Exception $e) {
+					// MariaDB syntax
+					$wpdb->get_var( // phpcs:ignore
+						$wpdb->prepare( "ALTER TABLE $table_results
+					DROP CONSTRAINT %1s;", array( $result_foreign_key ) )
+					);
+				} finally {
+					// Add replacement constraint
+					$wpdb->get_var( // phpcs:ignore
+						$wpdb->prepare( "ALTER TABLE $table_results
+					ADD CONSTRAINT %1s FOREIGN KEY(pid) REFERENCES $table_urls (pid) ON DELETE CASCADE", $results_constraint)
+					);
+				}
+			} else {
 				// Add new constraint
 				$wpdb->get_var( // phpcs:ignore
-					$wpdb->prepare( "ALTER TABLE $table_dismissals
-        			ADD CONSTRAINT %1s FOREIGN KEY(pid) REFERENCES $table_urls (pid) ON DELETE CASCADE", $dismissal_constraint)
+					$wpdb->prepare( "ALTER TABLE $table_results
+					ADD CONSTRAINT %1s FOREIGN KEY(pid) REFERENCES $table_urls (pid) ON DELETE CASCADE", $results_constraint)
 				);
 			}
-		} else {
-			$wpdb->get_var( // phpcs:ignore
-				$wpdb->prepare( "ALTER TABLE $table_dismissals
-        			ADD CONSTRAINT %1s FOREIGN KEY(pid) REFERENCES $table_urls (pid) ON DELETE CASCADE", $dismissal_constraint)
-			);
 		}
 
+		$dismissal_create_table_sql_row = $wpdb->get_row( "SHOW CREATE TABLE $table_dismissals" );
+		if ( $dismissal_create_table_sql_row ) {
+			$dismissal_create_table_sql = $dismissal_create_table_sql_row->{'Create Table'};
+			$dismissal_constraint       = $wpdb->prefix . 'ed11y_dismissal_pid';
+
+			$dissmissal_constraint_matches = preg_match( '/CONSTRAINT `(.+?)` FOREIGN KEY \(`pid`\)/', $dismissal_create_table_sql, $dismissal_matches );
+
+			$dismissal_key = null;
+			if ( $dissmissal_constraint_matches ) {
+				$dismissal_key = $dismissal_matches[1];
+			}
+
+			if ( $dismissal_key ) {
+				try {
+					// MySQL syntax
+					$wpdb->get_var( // phpcs:ignore
+						$wpdb->prepare( "ALTER TABLE $table_dismissals
+						DROP FOREIGN KEY %1s;", array( $dismissal_key ) )
+					);
+				} catch (Exception $e) {
+					// MariaDB syntax
+					$wpdb->get_var( // phpcs:ignore
+						$wpdb->prepare( "ALTER TABLE $table_dismissals
+						DROP CONSTRAINT %1s;", array( $dismissal_key ) )
+					);
+				} finally {
+					// Add new constraint
+					$wpdb->get_var( // phpcs:ignore
+						$wpdb->prepare( "ALTER TABLE $table_dismissals
+						ADD CONSTRAINT %1s FOREIGN KEY(pid) REFERENCES $table_urls (pid) ON DELETE CASCADE", $dismissal_constraint)
+					);
+				}
+			} else {
+				$wpdb->get_var( // phpcs:ignore
+					$wpdb->prepare( "ALTER TABLE $table_dismissals
+						ADD CONSTRAINT %1s FOREIGN KEY(pid) REFERENCES $table_urls (pid) ON DELETE CASCADE", $dismissal_constraint)
+				);
+			}
+		}
 	}
 
 	/**

--- a/editoria11y.php
+++ b/editoria11y.php
@@ -268,17 +268,23 @@ class Editoria11y {
 		// Lazy DB creation
 
 		$tableCheck = get_option( "editoria11y_db_version" );
-		if ( $tableCheck === '1.1-failed' ) {
+
+		if ( '-failed' === substr( $tableCheck, -7 ) ) {
 			// Tables are broken, don't try again until next release
 			return false;
-		} else if ( $tableCheck !== '1.1' ) {
-			// Create DB and set option based on success
-			update_option( "editoria11y_db_version", '1.1-failed' );
-			self::create_database();
-			update_option( "editoria11y_db_version", '1.1' );
 		}
-		return true;
 
+		if ( version_compare( $tableCheck, '1.2', '>=' ) ) {
+			// Tables are up to date
+			return true;
+		}
+
+		// Create DB and set option based on success
+		update_option( 'editoria11y_db_version', '1.2-failed' );
+		self::create_database();
+		update_option( 'editoria11y_db_version', '1.2' );
+
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
A client is using the `editoria11y-accessibility-checker` WP plugin on a very large WP Multisite install. After the most recent upgrade 1.0.18, we began experiencing extreme slowdowns throughout the network, which we tracked to the database upgrade routines. Specifically, queries against `INFORMATION_SCHEMA` were taking many minutes to complete, and resulted not only in failed upgrades, but managed to crash our site a few times:

https://github.com/itmaybejj/editoria11y-wp/blob/c26ef57b487937efdf11b9ba7dad98746373ad39/editoria11y.php#L184

https://github.com/itmaybejj/editoria11y-wp/blob/c26ef57b487937efdf11b9ba7dad98746373ad39/editoria11y.php#L221

In version 1.0.18 you made some changes that limited the situations in which database upgrade routines would be run. See #32. This was a good change, but it only addresses the frequency of the routine, not the routine itself.

For context, the WP installation in question has about 40k sites, and so the database has hundreds of thousands of database tables. `INFORMATION_SCHEMA` queries involve creating views that are extremely resource intensive on databases of this size.

Your purpose for querying `INFORMATION_SCHEMA` is to detect the presence of foreign-key constraints. The same thing can be accomplished by using `SHOW CREATE TABLE`. This approach has a minimal memory footprint, and the resulting string contains the necessary information to determine the presence of constraints. See f4c4b13da83f8e9dc8f6e39dd8e006db0659b424. I've tested this on my client's installation and it works well for new activations, for `1.1-failed` reinstalls, and for `1.0` upgrades.

I also added updated logic for 'editoria11y_db_version' 3e14ade67e4ee08baf5b989e84e86f5fd75dc966 Feel free to keep or discard this as you see fit - I just wanted to make it the PR more plug-and-play.
