### PR TITLE
Improve network deinstallation

### DIFF
--- a/editoria11y.php
+++ b/editoria11y.php
@@ -304,43 +304,13 @@ class Editoria11y {
 
 		global $wpdb;
 
-		if ( $network ) {
+		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}ed11y_dismissals" ); // phpcs:ignore
+		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}ed11y_results" ); // phpcs:ignore
+		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}ed11y_urls" ); // phpcs:ignore
 
-			$sites = get_sites(
-				array(
-					'number'     => 10000,
-					'fields'     =>'ids',
-					'network_id' => get_current_network_id(),
-				)
-			);
-
-			foreach ( $sites as $siteid ) {
-
-				switch_to_blog( $siteid );
-
-				$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}ed11y_dismissals" ); // phpcs:ignore
-				$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}ed11y_results" ); // phpcs:ignore
-				$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}ed11y_urls" ); // phpcs:ignore
-
-				delete_option( 'ed11y_plugin_settings' );
-				delete_option( 'editoria11y_db_version' );
-				delete_site_transient( 'editoria11y_settings' );
-
-				restore_current_blog();
-
-			}
-
-		} else {
-
-			$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}ed11y_dismissals" ); // phpcs:ignore
-			$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}ed11y_results" ); // phpcs:ignore
-			$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}ed11y_urls" ); // phpcs:ignore
-
-			delete_option( 'ed11y_plugin_settings' );
-			delete_option( 'editoria11y_db_version' );
-			delete_site_transient( 'editoria11y_settings' );
-
-		}
+		delete_option( 'ed11y_plugin_settings' );
+		delete_option( 'editoria11y_db_version' );
+		delete_site_transient( 'editoria11y_settings' );
 
 	}
 

--- a/editoria11y.php
+++ b/editoria11y.php
@@ -353,7 +353,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 // Manage DB tables.
 register_activation_hook( __FILE__, array( 'Editoria11y', 'activate' ) );
-register_deactivation_hook( __FILE__, array( 'Editoria11y', 'uninstall' ) );
 register_uninstall_hook( __FILE__, array( 'Editoria11y', 'uninstall' ) );
 
 new Editoria11y();


### PR DESCRIPTION
I recently faced a problem on a client's large Multisite installation. The editoria11y plugin triggered an uninstall routine that used a huge amount of database overhead. We traced it back to the `uninstall()` method in the main plugin file.

This PR suggests a few changes:

1. Never run the plugin uninstall routine on plugin deactivation. Deactivation is not the same thing as uninstalling. WordPress users are often encouraged to deactivate and then reactivate plugins in order to troubleshoot various issues. As such, plugins should not perform destruction actions during deactivation routines - they should be saved for explicit uninstalls.
2. Stop looping through all sites during uninstall. This does not scale, and the attempt to avoid performance issues by only (!) querying for 10000 sites means that the job is incompletely done anyway. While I think it's generally a good practice for a plugin to clean up after itself on deletion, it's not worth this kind of risk; better, IMO, to leave the tables and options intact. If you really and truly need a network-uninstall routine, it should be put on its own Network Admin panel, with some sort of asynchronous mechanism (AJAX, progress bar, etc) that requires manual triggering by the installation administrator. (For the record, I don't think this is necessary. Just leave the tables. But if you really wanted to offer a way to get rid of them, it should be something like this.)